### PR TITLE
Added more missing strings

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/npc_tf2_ghost.lua
+++ b/garrysmod/gamemodes/base/entities/entities/npc_tf2_ghost.lua
@@ -66,7 +66,7 @@ end
 -- List the NPC as spawnable
 --
 list.Set( "NPC", "npc_tf2_ghost", {
-	Name = "Example NPC",
+	Name = "#npc_gmod_nextbot_example",
 	Class = "npc_tf2_ghost",
-	Category = "Nextbot"
+	Category = "#spawnmenu.npcs.category.nextbot"
 } )

--- a/garrysmod/gamemodes/base/entities/weapons/weapon_base/cl_init.lua
+++ b/garrysmod/gamemodes/base/entities/weapons/weapon_base/cl_init.lua
@@ -67,12 +67,14 @@ function SWEP:PrintWeaponInfo( x, y, alpha )
 	if ( self.InfoMarkup == nil ) then
 		local title_color = "<color=230,230,230,255>"
 		local text_color = "<color=150,150,150,255>"
+		local c_end1 = "</color>\t"
+		local c_end2 = "</color>\n"
 
 		local str = "<font=HudSelectionText>"
-		if ( self.Author != "" ) then str = str .. title_color .. "Author:</color>\t" .. text_color .. self.Author .. "</color>\n" end
-		if ( self.Contact != "" ) then str = str .. title_color .. "Contact:</color>\t" .. text_color .. self.Contact .. "</color>\n\n" end
-		if ( self.Purpose != "" ) then str = str .. title_color .. "Purpose:</color>\n" .. text_color .. self.Purpose .. "</color>\n\n" end
-		if ( self.Instructions != "" ) then str = str .. title_color .. "Instructions:</color>\n" .. text_color .. self.Instructions .. "</color>\n" end
+		if ( self.Author != "" ) then str = str .. title_color .. "#weaponselector_author" .. c_end1 .. text_color .. self.Author .. c_end2 end
+		if ( self.Contact != "" ) then str = str .. title_color .. "#weaponselector_contact" .. c_end1 .. text_color .. self.Contact .. c_end2 .. "\n" end
+		if ( self.Purpose != "" ) then str = str .. title_color .. "#weaponselector_purpose" .. c_end2 .. text_color .. self.Purpose .. c_end2 .. "\n" end
+		if ( self.Instructions != "" ) then str = str .. title_color .. "#weaponselector_instructions" .. c_end2 .. text_color .. self.Instructions .. c_end2 end
 		str = str .. "</font>"
 
 		self.InfoMarkup = markup.Parse( str, 250 )

--- a/garrysmod/gamemodes/sandbox/entities/entities/edit_fog.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/edit_fog.lua
@@ -6,7 +6,7 @@ ENT.Spawnable = true
 ENT.AdminOnly = true
 
 ENT.PrintName = "#edit_fog"
-ENT.Category = "#ent.editors"
+ENT.Category = "#spawnmenu.ents.category.editors"
 ENT.Information = "Right click on this entity via the context menu (hold C by default) and select 'Edit Properties' to edit the fog."
 
 function ENT:Initialize()

--- a/garrysmod/gamemodes/sandbox/entities/entities/edit_sky.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/edit_sky.lua
@@ -6,7 +6,7 @@ ENT.Spawnable = true
 ENT.AdminOnly = true
 
 ENT.PrintName = "#edit_sky"
-ENT.Category = "#ent.editors"
+ENT.Category = "#spawnmenu.ents.category.editors"
 ENT.Information = "Right click on this entity via the context menu (hold C by default) and select 'Edit Properties' to edit the sky."
 
 function ENT:Initialize()

--- a/garrysmod/gamemodes/sandbox/entities/entities/edit_sun.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/edit_sun.lua
@@ -6,7 +6,7 @@ ENT.Spawnable = true
 ENT.AdminOnly = true
 
 ENT.PrintName = "#edit_sun"
-ENT.Category = "#ent.editors"
+ENT.Category = "#spawnmenu.ents.category.editors"
 ENT.Information = "Right click on this entity via the context menu (hold C by default) and select 'Edit Properties' to edit the sun. Rotate the entity to move the sun."
 
 function ENT:Initialize()

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/custom.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/custom.lua
@@ -206,7 +206,7 @@ hook.Add( "PopulateContent", "AddCustomContent", function( pnlContent, tree, nod
 	node.DoRightClick = function( self )
 
 		local menu = DermaMenu()
-		menu:AddOption( "New Category", function() AddCustomizableNode( pnlContent, "New Category", "", node ) node:SetExpanded( true ) hook.Run( "SpawnlistContentChanged" ) end ):SetIcon( "icon16/folder_add.png" )
+		menu:AddOption( "#spawnmenu.menu.new_category", function() AddCustomizableNode( pnlContent, "#spawnmenu.menu.new_category", "", node ) node:SetExpanded( true ) hook.Run( "SpawnlistContentChanged" ) end ):SetIcon( "icon16/folder_add.png" )
 		menu:Open()
 
 	end

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/entities.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/entities.lua
@@ -12,7 +12,7 @@ hook.Add( "PopulateEntities", "AddEntityContent", function( pnlContent, tree, br
 	if ( SpawnableEntities ) then
 		for k, v in pairs( SpawnableEntities ) do
 
-			local Category = v.Category or "Other"
+			local Category = v.Category or language.GetPhrase( "general_other_noname" )
 			if ( !isstring( Category ) ) then Category = tostring( Category ) end
 			Categorised[ Category ] = Categorised[ Category ] or {}
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/entities.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/entities.lua
@@ -12,7 +12,7 @@ hook.Add( "PopulateEntities", "AddEntityContent", function( pnlContent, tree, br
 	if ( SpawnableEntities ) then
 		for k, v in pairs( SpawnableEntities ) do
 
-			local Category = v.Category or language.GetPhrase( "general_other_noname" )
+			local Category = v.Category or "#general_other_noname"
 			if ( !isstring( Category ) ) then Category = tostring( Category ) end
 			Categorised[ Category ] = Categorised[ Category ] or {}
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
@@ -8,7 +8,7 @@ hook.Add( "PopulateNPCs", "AddNPCContent", function( pnlContent, tree, browseNod
 	local Categories = {}
 	for k, v in pairs( NPCList ) do
 
-		local Category = v.Category or language.GetPhrase( "general_other_noname" )
+		local Category = v.Category or "#general_other_noname"
 		if ( !isstring( Category ) ) then Category = tostring( Category ) end
 
 		local Tab = Categories[ Category ] or {}

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
@@ -8,7 +8,7 @@ hook.Add( "PopulateNPCs", "AddNPCContent", function( pnlContent, tree, browseNod
 	local Categories = {}
 	for k, v in pairs( NPCList ) do
 
-		local Category = v.Category or "Other"
+		local Category = v.Category or language.GetPhrase( "general_other_noname" )
 		if ( !isstring( Category ) ) then Category = tostring( Category ) end
 
 		local Tab = Categories[ Category ] or {}

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/postprocess.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/postprocess.lua
@@ -10,7 +10,7 @@ hook.Add( "PopulatePostProcess", "AddPostProcess", function( pnlContent, tree, n
 
 		for k, v in pairs( PostProcess ) do
 
-			local Category = v.category or "#spawnmenu.altcategory.other"
+			local newCategory = weapon.Category or language.GetPhrase( "general_other_noname" )
 			if ( !isstring( Category ) ) then Category = tostring( Category ) end
 			Categorised[ Category ] = Categorised[ Category ] or {}
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/postprocess.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/postprocess.lua
@@ -10,7 +10,7 @@ hook.Add( "PopulatePostProcess", "AddPostProcess", function( pnlContent, tree, n
 
 		for k, v in pairs( PostProcess ) do
 
-			local newCategory = weapon.Category or language.GetPhrase( "general_other_noname" )
+			local Category = v.category or "#general_other_noname"
 			if ( !isstring( Category ) ) then Category = tostring( Category ) end
 			Categorised[ Category ] = Categorised[ Category ] or {}
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
@@ -8,7 +8,7 @@ hook.Add( "PopulateVehicles", "AddEntityContent", function( pnlContent, tree, br
 	if ( Vehicles ) then
 		for k, v in pairs( Vehicles ) do
 
-			local Category = v.Category or "Other"
+			local Category = v.Category or language.GetPhrase( "general_other_noname" )
 			if ( !isstring( Category ) ) then Category = tostring( Category ) end
 			Categorised[ Category ] = Categorised[ Category ] or {}
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
@@ -8,7 +8,7 @@ hook.Add( "PopulateVehicles", "AddEntityContent", function( pnlContent, tree, br
 	if ( Vehicles ) then
 		for k, v in pairs( Vehicles ) do
 
-			local Category = v.Category or language.GetPhrase( "general_other_noname" )
+			local Category = v.Category or "#general_other_noname"
 			if ( !isstring( Category ) ) then Category = tostring( Category ) end
 			Categorised[ Category ] = Categorised[ Category ] or {}
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
@@ -8,7 +8,7 @@ local function BuildWeaponCategories()
 
 		if ( !weapon.Spawnable ) then continue end
 
-		local Category = weapon.Category or language.GetPhrase( "general_other_noname" )
+		local Category = weapon.Category or "#general_other_noname"
 		if ( !isstring( Category ) ) then Category = tostring( Category ) end
 
 		Categorised[ Category ] = Categorised[ Category ] or {}
@@ -116,7 +116,7 @@ local function AutorefreshWeaponToSpawnmenu( weapon, name )
 	end
 
 	-- Add to new category.. by rebuilding it
-	local category = weapon.Category or language.GetPhrase( "general_other_noname" )
+	local category = weapon.Category or "#general_other_noname"
 
 	if ( IsValid( tree.Categories[ category ] ) ) then
 		if ( IsValid( tree.Categories[ category ].PropPanel ) ) then

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
@@ -8,7 +8,7 @@ local function BuildWeaponCategories()
 
 		if ( !weapon.Spawnable ) then continue end
 
-		local Category = weapon.Category or "Other"
+		local Category = weapon.Category or language.GetPhrase( "general_other_noname" )
 		if ( !isstring( Category ) ) then Category = tostring( Category ) end
 
 		Categorised[ Category ] = Categorised[ Category ] or {}
@@ -116,7 +116,7 @@ local function AutorefreshWeaponToSpawnmenu( weapon, name )
 	end
 
 	-- Add to new category.. by rebuilding it
-	local category = weapon.Category or "Other"
+	local category = weapon.Category or language.GetPhrase( "general_other_noname" )
 
 	if ( IsValid( tree.Categories[ category ] ) ) then
 		if ( IsValid( tree.Categories[ category ].PropPanel ) ) then

--- a/garrysmod/lua/autorun/base_npcs.lua
+++ b/garrysmod/lua/autorun/base_npcs.lua
@@ -10,7 +10,7 @@ end
 
 
 
-local Category = "Humans + Resistance"
+local Category = "#spawnmenu.npcs.category.humans_and_resistance"
 
 AddNPC( {
 	Class = "npc_alyx",
@@ -148,7 +148,7 @@ if ( IsMounted( "ep2" ) ) then
 
 end
 
-Category = "Zombies + Enemy Aliens"
+Category = "#spawnmenu.npcs.category.zombie_and_enemy_aliens"
 
 AddNPC( {
 	Class = "npc_zombie",
@@ -253,7 +253,7 @@ end
 
 
 
-Category = "Animals"
+Category = "#spawnmenu.npcs.category.animals"
 
 AddNPC( {
 	Class = "npc_monk",
@@ -281,7 +281,7 @@ AddNPC( {
 
 
 
-Category = "Combine"
+Category = "#spawnmenu.npcs.category.combine"
 
 AddNPC( {
 	Class = "npc_metropolice",

--- a/garrysmod/lua/autorun/base_vehicles.lua
+++ b/garrysmod/lua/autorun/base_vehicles.lua
@@ -69,7 +69,7 @@ if ( IsMounted( "ep2" ) ) then
 	}, "Jalopy" )
 end
 
-Category = "Chairs"
+Category = "#spawnmenu.vehicles.category.chairs"
 
 local function HandleRollercoasterAnimation( vehicle, player )
 	return player:SelectWeightedSequence( ACT_GMOD_SIT_ROLLERCOASTER )

--- a/garrysmod/lua/autorun/game_hl2.lua
+++ b/garrysmod/lua/autorun/game_hl2.lua
@@ -142,5 +142,5 @@ if ( IsMounted( "portal" ) ) then
 	ADD_ITEM( "prop_glados_core", 32, { KeyValues = { CoreType = 3 } }, "prop_glados_core_morality" )
 end
 
-Category = "#spawnmenu.altcategory.other"
+Category = "#general_other_noname"
 ADD_WEAPON( "weapon_physgun" )

--- a/garrysmod/lua/entities/sent_ball.lua
+++ b/garrysmod/lua/entities/sent_ball.lua
@@ -6,7 +6,7 @@ DEFINE_BASECLASS( "base_anim" )
 ENT.PrintName = "#sent_ball"
 ENT.Author = "Garry Newman"
 ENT.Information = "An edible bouncy ball. Press USE on the bouncy ball to eat it."
-ENT.Category = "#ent.fun.games"
+ENT.Category = "#spawnmenu.ents.category.funandgames"
 
 ENT.Editable = true
 ENT.Spawnable = true

--- a/garrysmod/lua/includes/modules/weapons.lua
+++ b/garrysmod/lua/includes/modules/weapons.lua
@@ -58,7 +58,7 @@ function Register( t, name )
 	list.Set( "Weapon", name, {
 		ClassName = name,
 		PrintName = t.PrintName or name,
-		Category = t.Category or "#spawnmenu.altcategory.other",
+		Category = t.Category or "#general_other_noname",
 		Spawnable = t.Spawnable,
 		AdminOnly = t.AdminOnly,
 		ScriptedEntityType = t.ScriptedEntityType,

--- a/garrysmod/lua/menu/getmaps.lua
+++ b/garrysmod/lua/menu/getmaps.lua
@@ -357,7 +357,7 @@ local function RefreshMaps( skip )
 		end
 
 		-- Throw all uncategorised maps into Other
-		Category = Category or "Other"
+		Category = Category or language.GetPhrase( "general_other_noname" )
 
 		local fav
 

--- a/garrysmod/resource/localization/en/entities.properties
+++ b/garrysmod/resource/localization/en/entities.properties
@@ -14,6 +14,9 @@ edit_sky=Sky Editor
 edit_sun=Sun Editor
 sent_ball=Bouncy Ball
 
+# Garry's Mod NPCs
+npc_gmod_nextbot_example=Example NPC
+
 # Half-Life 2 weapons
 weapon_357=.357 Magnum
 weapon_alyxgun=Alyx's Gun
@@ -214,3 +217,9 @@ prop_glados_core_morality=Morality Core
 npc_portal_turret_floor=Sentry Turret
 npc_rocket_turret=Rocket Turret
 npc_security_camera=Security Camera
+
+# Weapon selector descriptions
+weaponselector_author=Author\:
+weaponselector_contact=Contact\:
+weaponselector_purpose=Purpose\:
+weaponselector_instructions=Instructions\:

--- a/garrysmod/resource/localization/en/spawnmenu.properties
+++ b/garrysmod/resource/localization/en/spawnmenu.properties
@@ -28,6 +28,7 @@ spawnmenu.menu.edit=Edit
 spawnmenu.menu.new=New
 spawnmenu.menu.copy_dnd=Copy
 spawnmenu.menu.move=Move
+spawnmenu.menu.new_category=New Category
 spawnmenu.menu.add_subcategory=Add subcategory
 spawnmenu.menu.edit_icon=Edit icon
 spawnmenu.menu.resize=Resize

--- a/garrysmod/resource/localization/en/spawnmenu.properties
+++ b/garrysmod/resource/localization/en/spawnmenu.properties
@@ -173,7 +173,7 @@ spawnmenu.ents.category.funandgames=Fun + Games
 spawnmenu.ents.category.editors=Editors
 # NPCs
 spawnmenu.npcs.category.humans_and_resistance=Humans + Resistance
-spawnmenu.npcs.category.zombie_and_nenemy_aliens=Zombies + Enemy Aliens
+spawnmenu.npcs.category.zombie_and_enemy_aliens=Zombies + Enemy Aliens
 spawnmenu.npcs.category.animals=Animals
 spawnmenu.npcs.category.combine=Combine
 spawnmenu.npcs.category.nextbot=Nextbot

--- a/garrysmod/resource/localization/en/spawnmenu.properties
+++ b/garrysmod/resource/localization/en/spawnmenu.properties
@@ -13,7 +13,6 @@ spawnmenu.category.entities=Entities
 spawnmenu.category.vehicles=Vehicles
 spawnmenu.category.dupes=Dupes
 spawnmenu.category.saves=Saves
-spawnmenu.altcategory.other=Other
 
 spawnmenu.tools_tab=Tools
 spawnmenu.tools.constraints=Constraints
@@ -72,9 +71,6 @@ spawnmenu.utilities.undo.help=Undo a previous action.
 spawnmenu.utilities.physgunsettings=Physics Gun Settings
 spawnmenu.utilities.sandbox_settings=Sandbox Settings
 spawnmenu.utilities.server_settings=Server Settings
-
-ent.fun.games=Fun + Games
-ent.editors=Editors
 
 utilities.serversettings=Server Settings. These settings can only be changed by the person who created the game server through the main menu.
 utilities.password=Server Password\:
@@ -170,3 +166,19 @@ spawnmenu.seat.airboat=Airboat Seat
 spawnmenu.seat.simple_sit=Car Seat (Sit)
 spawnmenu.seat.simple_jeep=Car Seat (Jeep)
 spawnmenu.seat.simple_airboat=Car Seat (Airboat)
+
+# Tabs categories
+# Entities
+spawnmenu.ents.category.funandgames=Fun + Games
+spawnmenu.ents.category.editors=Editors
+# NPCs
+spawnmenu.npcs.category.humans_and_resistance=Humans + Resistance
+spawnmenu.npcs.category.zombie_and_nenemy_aliens=Zombies + Enemy Aliens
+spawnmenu.npcs.category.animals=Animals
+spawnmenu.npcs.category.combine=Combine
+spawnmenu.npcs.category.nextbot=Nextbot
+# Vehicles
+spawnmenu.vehicles.category.chairs=Chairs
+
+# Other category (if there is none)
+general_other_noname=Other


### PR DESCRIPTION
- Added localization support for the "Other" category (for everything that doesn't have it's own category) in places like the new game menu or ents, sweps and similar tabs.
- Added localization support for categories in ents, sweps and similar tabs.
- Added localization support for weapons descriptions labels (not the description itself) in the weapon selector.
- Added localization support the "New category" option in spawn menu (new category also gets the same localization)

![image](https://github.com/user-attachments/assets/476d52bb-9451-4509-bd69-b33a267f6b96)
![image](https://github.com/user-attachments/assets/b96bb753-5f60-4be1-aade-91739ab07c53)
![image](https://github.com/user-attachments/assets/1fcae356-40f9-499c-8f41-1727d01c8a48)
![image](https://github.com/user-attachments/assets/73c1490b-5fca-48c2-9531-2f91bd1d01ad)
![image](https://github.com/user-attachments/assets/eaee5eac-3c16-487b-ab39-2547ebffcb94)
![image](https://github.com/user-attachments/assets/66dee74c-4771-453d-8733-090be1ee2e8c)
![image](https://github.com/user-attachments/assets/13993371-4e5a-41b6-87a2-244db1579939)

