### PR TITLE
npc_gmod_nextbot_example → npc_tf2_ghost

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/npc_tf2_ghost.lua
+++ b/garrysmod/gamemodes/base/entities/entities/npc_tf2_ghost.lua
@@ -66,7 +66,7 @@ end
 -- List the NPC as spawnable
 --
 list.Set( "NPC", "npc_tf2_ghost", {
-	Name = "#npc_gmod_nextbot_example",
+	Name = "#npc_tf2_ghost",
 	Class = "npc_tf2_ghost",
 	Category = "#spawnmenu.npcs.category.nextbot"
 } )

--- a/garrysmod/resource/localization/en/entities.properties
+++ b/garrysmod/resource/localization/en/entities.properties
@@ -15,7 +15,7 @@ edit_sun=Sun Editor
 sent_ball=Bouncy Ball
 
 # Garry's Mod NPCs
-npc_gmod_nextbot_example=Example NPC
+npc_tf2_ghost=Example NPC
 
 # Half-Life 2 weapons
 weapon_357=.357 Magnum


### PR DESCRIPTION
This will prevent unnecessary strings to be added after  https://github.com/Facepunch/garrysmod/pull/2166

This also fits more since other entities called the same way.